### PR TITLE
passing int to Timer constructor as specified by API on non-openfl or flash targets

### DIFF
--- a/motion/actuators/SimpleActuator.hx
+++ b/motion/actuators/SimpleActuator.hx
@@ -72,7 +72,7 @@ class SimpleActuator extends GenericActuator {
 			#if (flash || nme || openfl)
 			Lib.current.stage.addEventListener (Event.ENTER_FRAME, stage_onEnterFrame);
 			#else
-			timer = new Timer (1000 / 30);
+			timer = new Timer (Std.int(1000 / 30));
 			timer.run = stage_onEnterFrame;
 			#end
 			

--- a/motion/actuators/SimpleActuator.hx
+++ b/motion/actuators/SimpleActuator.hx
@@ -276,7 +276,6 @@ class SimpleActuator extends GenericActuator {
 	
 	
 	private inline function setField (target:Dynamic, propertyName:String, value:Dynamic):Void {
-		
 		if (Reflect.hasField (target, propertyName)) {
 			
 			#if flash
@@ -297,23 +296,9 @@ class SimpleActuator extends GenericActuator {
 	
 	
 	private inline function setProperty (details:PropertyDetails, value:Dynamic):Void {
-		
-		if (details.isField) {
-			
-			#if flash
-			untyped details.target[details.propertyName] = value;
-			#else
-			Reflect.setField (details.target, details.propertyName, value);
-			#end
-			
-		} else {
-			
-			#if (haxe_209 || haxe3)
-			Reflect.setProperty (details.target, details.propertyName, value);
-			#end
-			
-		}
-		
+        #if (haxe_209 || haxe3)
+        Reflect.setProperty (details.target, details.propertyName, value);
+        #end
 	}
 	
 	


### PR DESCRIPTION
Without this, there is this compilation error:
/usr/lib/haxe/lib/Actuate/1,6,8/motion/actuators/SimpleActuator.hx:75: characters 22-31 : Float should be Int
/usr/lib/haxe/lib/Actuate/1,6,8/motion/actuators/SimpleActuator.hx:75: characters 22-31 : For function argument 'time_ms'