### PR TITLE
Automatic BitmapFilter creation in FilterActuator

### DIFF
--- a/motion/actuators/FilterActuator.hx
+++ b/motion/actuators/FilterActuator.hx
@@ -28,6 +28,10 @@ class FilterActuator extends SimpleActuator {
 			
 			filterClass = properties.filter;
 			
+			if (target.filters.length == 0) {
+				target.filters = [Type.createInstance(filterClass, [])];
+			}
+			
 			for (filter in cast (target, DisplayObject).filters) {
 				
 				if (Std.is (filter, filterClass)) {


### PR DESCRIPTION
This creates a BitmapFilter when the user tries to use `Actuate.effects(target, duration).filter(...)` without having created and added the specific filter to `target.filters` array.

It prevents a runtime error the user will get if he/she tries to use filters and tweening using the explanation provided in the readme.md. This is related to issue #36.