### PR TITLE
Fix for tweening fields with setters on neko target

### DIFF
--- a/motion/actuators/SimpleActuator.hx
+++ b/motion/actuators/SimpleActuator.hx
@@ -303,7 +303,7 @@ class SimpleActuator extends GenericActuator {
 			#if flash
 			untyped details.target[details.propertyName] = value;
 			#else
-			Reflect.setField (details.target, details.propertyName, value);
+			Reflect.setProperty (details.target, details.propertyName, value);
 			#end
 			
 		} else {


### PR DESCRIPTION
Tweening fields that have setters does not work on neko targets. 