### PR TITLE
fix: MethodActuator is still updating while being paused

### DIFF
--- a/motion/actuators/MethodActuator.hx
+++ b/motion/actuators/MethodActuator.hx
@@ -32,7 +32,6 @@ class MethodActuator<T> extends SimpleActuator<T, T> {
 			currentParameters.push (this.properties.start[i]);
 			
 		}
-		
 	}
 	
 	
@@ -75,7 +74,7 @@ class MethodActuator<T> extends SimpleActuator<T, T> {
 		
 		super.update (currentTime);
 		
-		if (active) {
+		if (active && !paused) {
 			
 			for (i in 0...properties.start.length) {
 				


### PR DESCRIPTION
If you are using Acutate.update() and Acuate.pauseAll() or pause() for specific actuator, MethodActuator still continues to update it's method after being paused.
Also, it leeds to undefined behaviour if MethodActuator was paused before being initialized - it can happen if Actuate.pauseAll() called immidiately after Acutate.update().
So here is a fix for it :)