### PR TITLE
Math.exp is faster than Math.pow

### DIFF
--- a/motion/easing/Elastic.hx
+++ b/motion/easing/Elastic.hx
@@ -62,7 +62,7 @@ class ElasticEaseIn implements IEasing {
 		var s:Float;
 		if (a < 1) { a = 1; s = p / 4; }
 		else s = p / (2 * Math.PI) * Math.asin (1 / a);
-		return -(a * Math.pow(2, 10 * (k -= 1)) * Math.sin( (k - s) * (2 * Math.PI) / p ));
+		return -(a * Math.exp(6.931471805599453 * (k -= 1)) * Math.sin( (k - s) * (2 * Math.PI) / p ));
 		
 	}
 	
@@ -83,7 +83,7 @@ class ElasticEaseIn implements IEasing {
 		else {
 			s = p / (2 * Math.PI) * Math.asin(c / a);
 		}
-		return -(a * Math.pow(2, 10 * (t -= 1)) * Math.sin((t * d - s) * (2 * Math.PI) / p)) + b;
+		return -(a * Math.exp(6.931471805599453 * (t -= 1)) * Math.sin((t * d - s) * (2 * Math.PI) / p)) + b;
 		
 	}
 	
@@ -119,9 +119,9 @@ class ElasticEaseInOut implements IEasing {
 		var s:Float = p / 4;
 		
 		if (k < 1) {
-			return -0.5 * (Math.pow(2, 10 * (k -= 1)) * Math.sin((k - s) * (2 * Math.PI) / p));
+			return -0.5 * (Math.exp(6.931471805599453 * (k -= 1)) * Math.sin((k - s) * (2 * Math.PI) / p));
 		}
-		return Math.pow(2, -10 * (k -= 1)) * Math.sin((k - s) * (2 * Math.PI) / p) * 0.5 + 1;
+		return Math.exp(-6.931471805599453 * (k -= 1)) * Math.sin((k - s) * (2 * Math.PI) / p) * 0.5 + 1;
 		
 	}
 	
@@ -143,9 +143,9 @@ class ElasticEaseInOut implements IEasing {
 			s = p / (2 * Math.PI) * Math.asin(c / a);
 		}
 		if (t < 1) {
-			return -0.5 * (a * Math.pow(2, 10 * (t -= 1)) * Math.sin((t * d - s) * (2 * Math.PI) / p)) + b;
+			return -0.5 * (a * Math.exp(6.931471805599453 * (t -= 1)) * Math.sin((t * d - s) * (2 * Math.PI) / p)) + b;
 		}
-		return a * Math.pow(2, -10 * (t -= 1)) * Math.sin((t * d - s) * (2 * Math.PI) / p) * 0.5 + c + b;
+		return a * Math.exp(-6.931471805599453 * (t -= 1)) * Math.sin((t * d - s) * (2 * Math.PI) / p) * 0.5 + c + b;
 		
 	}
 	
@@ -174,7 +174,7 @@ class ElasticEaseOut implements IEasing {
 		var s:Float;
 		if (a < 1) { a = 1; s = p / 4; }
 		else s = p / (2 * Math.PI) * Math.asin (1 / a);
-		return (a * Math.pow(2, -10 * k) * Math.sin((k - s) * (2 * Math.PI) / p ) + 1);
+		return (a * Math.exp(-6.931471805599453 * k) * Math.sin((k - s) * (2 * Math.PI) / p ) + 1);
 		
 	}
 	
@@ -195,7 +195,7 @@ class ElasticEaseOut implements IEasing {
 		else {
 			s = p / (2 * Math.PI) * Math.asin(c / a);
 		}
-		return a * Math.pow(2, -10 * t) * Math.sin((t * d - s) * (2 * Math.PI) / p) + c + b;
+		return a * Math.exp(-6.931471805599453 * t) * Math.sin((t * d - s) * (2 * Math.PI) / p) + c + b;
 		
 	}
 	

--- a/motion/easing/Expo.hx
+++ b/motion/easing/Expo.hx
@@ -52,14 +52,13 @@ class ExpoEaseIn implements IEasing {
 	
 	public function calculate (k:Float):Float {
 		
-		return k == 0 ? 0 : Math.pow(2, 10 * (k - 1));
-		
+		return k == 0 ? 0 : Math.exp(6.931471805599453 * (k - 1));
 	}
 	
 	
 	public function ease (t:Float, b:Float, c:Float, d:Float):Float {
 		
-		return t == 0 ? b : c * Math.pow(2, 10 * (t / d - 1)) + b;
+		return t == 0 ? b : c * Math.exp(6.931471805599453 * (t / d - 1)) + b;
 		
 	}
 	
@@ -82,9 +81,9 @@ class ExpoEaseInOut implements IEasing {
 		if (k == 0) { return 0; }
 		if (k == 1) { return 1; }
 		if ((k /= 1 / 2.0) < 1.0) {
-			return 0.5 * Math.pow(2, 10 * (k - 1));
+			return 0.5 * Math.exp(6.931471805599453 * (k - 1));
 		}
-		return 0.5 * (2 - Math.pow(2, -10 * --k));
+		return 0.5 * (2 - Math.exp(-6.931471805599453 * --k));
 		
 	}
 	
@@ -98,9 +97,9 @@ class ExpoEaseInOut implements IEasing {
 			return b + c;
 		}
 		if ((t /= d / 2.0) < 1.0) {
-			return c / 2 * Math.pow(2, 10 * (t - 1)) + b;
+			return c / 2 * Math.exp(6.931471805599453 * (t - 1)) + b;
 		}
-		return c / 2 * (2 - Math.pow(2, -10 * --t)) + b;
+		return c / 2 * (2 - Math.exp(-6.931471805599453 * --t)) + b;
 		
 	}
 	
@@ -120,14 +119,14 @@ class ExpoEaseOut implements IEasing {
 	
 	public function calculate (k:Float):Float {
 		
-		return k == 1 ? 1 : (1 - Math.pow(2, -10 * k));
+		return k == 1 ? 1 : (1 - Math.exp(-6.931471805599453 * k));
 		
 	}
 	
 	
 	public function ease (t:Float, b:Float, c:Float, d:Float):Float {
 		
-		return t == d ? b + c : c * (1 - Math.pow(2, -10 * t / d)) + b;
+		return t == d ? b + c : c * (1 - Math.exp(-6.931471805599453 * t / d)) + b;
 		
 	}
 	


### PR DESCRIPTION
`Math.pow(2, 10 * (t - 1))` can be rewritten with `Math.exp(log_e(2) * 10 * (t - 1))`, and [Math.exp is faster than Math.pow](https://github.com/shohei909/tweenx/blob/5d06c5fae32bcd6a282b4f2fa9ee8c57dd2346b9/test/benchmark.md).