### PR TITLE
do not accumulate state in BackEaseInOut

### DIFF
--- a/src/motion/easing/Back.hx
+++ b/src/motion/easing/Back.hx
@@ -76,23 +76,23 @@ private class BackEaseInOut implements IEasing {
 	
 	public function new (s:Float) {
 		
-		this.s = s;
+		this.s = s * 1.525;
 		
 	}
 	
 	
 	public function calculate (k:Float):Float {
 		
-		if ((k /= 0.5) < 1) return 0.5 * (k * k * (((s *= (1.525)) + 1) * k - s));
-		return 0.5 * ((k -= 2) * k * (((s *= (1.525)) + 1) * k + s) + 2);
+		if ((k /= 0.5) < 1) return 0.5 * (k * k * (((s) + 1) * k - s));
+		return 0.5 * ((k -= 2) * k * (((s) + 1) * k + s) + 2);
 		
 	}
 	
 	
 	public function ease (t:Float, b:Float, c:Float, d:Float):Float {
 		
-		if ((t/=d/2) < 1) return c/2*(t*t*(((s*=(1.525))+1)*t - s)) + b;
-		return c/2*((t-=2)*t*(((s*=(1.525))+1)*t + s) + 2) + b;
+		if ((t/=d/2) < 1) return c/2*(t*t*((s+1)*t - s)) + b;
+		return c/2*((t-=2)*t*((s+1)*t + s) + 2) + b;
 		
 	}
 	


### PR DESCRIPTION
This is a fix for issue #65 and provides a more complete fix than pull request #114 

Without this fix, _BackEaseInOut_ behaves erratically since the value `s` increases with each call to `ease` or `calculate`